### PR TITLE
Limit bytes read by Uvariant to <= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.17.x
 
 env:
   - GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dennwc/varint
 
-go 1.12
+go 1.17

--- a/varint.go
+++ b/varint.go
@@ -153,10 +153,11 @@ func Uvarint(buf []byte) (uint64, int) {
 		} else if sz == 10 {
 			return 0, 0
 		}
-		for j, b := range buf[10:] {
-			if b < bit {
-				return 0, -(11 + j)
-			}
+
+		if sz > MaxLen64 {
+			// Catch byte reads past MaxLen64.
+			// See issue https://golang.org/issues/41185
+			return 0, -(MaxLen64 + 1) // overflow
 		}
 		return 0, 0
 	}
@@ -261,10 +262,11 @@ func Uvarint(buf []byte) (uint64, int) {
 	} else if sz == 10 {
 		return 0, 0
 	}
-	for j, b := range buf[10:] {
-		if b < bit {
-			return 0, -(11 + j)
-		}
+
+	if sz > MaxLen64 {
+		// Catch byte reads past MaxLen64.
+		// See issue https://golang.org/issues/41185
+		return 0, -(MaxLen64 + 1) // overflow
 	}
 	return 0, 0
 }

--- a/varint_test.go
+++ b/varint_test.go
@@ -90,10 +90,10 @@ func TestUvarint(t *testing.T) {
 		b[1] = 0xff
 		n := binary.PutUvarint(b[2:], maxUint64)
 		p := b[:n+2]
-		if _, n2 := binary.Uvarint(p); n2 != -12 {
+		if _, n2 := binary.Uvarint(p); n2 != -11 {
 			t.Fatalf("unexpected error: %d", n2)
 		}
-		if _, n2 := Uvarint(p); n2 != -12 {
+		if _, n2 := Uvarint(p); n2 != -11 {
 			t.Fatalf("unexpected error: %d", n2)
 		}
 	})
@@ -104,10 +104,10 @@ func TestUvarint(t *testing.T) {
 		n := binary.PutUvarint(b[2:], maxUint64)
 		p := b[:n+2]
 		p[len(p)-1] = 0xff
-		if _, n2 := binary.Uvarint(p); n2 != 0 {
+		if _, n2 := binary.Uvarint(p); n2 != -11 {
 			t.Fatalf("unexpected error: %d", n2)
 		}
-		if _, n2 := Uvarint(p); n2 != 0 {
+		if _, n2 := Uvarint(p); n2 != -11 {
 			t.Fatalf("unexpected error: %d", n2)
 		}
 	})


### PR DESCRIPTION
This matches the change done in the upstream Go 1.17 compiler in  commit aafad20b617ee63d58fcd4f6e0d98fe27760678c.

Bump the go required version to 1.17 so that the test cases match what is implemented there.