### PR TITLE
Fix protobuf support on 32-bit architectures

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -3,7 +3,7 @@ package varint
 // ProtoTag decodes a protobuf's field number and wire type pair
 // from buf and returns that value and the number of bytes read (> 0).
 // If an error occurred, n = 0 is returned.
-func ProtoTag(buf []byte) (num int, typ byte, n int) {
+func ProtoTag(buf []byte) (num int64, typ byte, n int) {
 	// Same unrolled implementation as in Uvarint.
 	//
 	// But this time we can check if the wire type and field num
@@ -37,90 +37,90 @@ func ProtoTag(buf []byte) (num int, typ byte, n int) {
 			return 0, 0, 0
 		}
 		if b < bit {
-			num = int(b >> typBits)
+			num = int64(b >> typBits)
 			if num == 0 {
 				return 0, 0, 0
 			}
 			n = 1
 			return
 		}
-		num = int((b & mask) >> typBits)
+		num = int64((b & mask) >> typBits)
 		var s uint = step - typBits
 
 		// i == 1
 		b = buf[1]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 2
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 2
 		b = buf[2]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 3
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 3
 		b = buf[3]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 4
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 4
 		b = buf[4]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 5
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 5
 		b = buf[5]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 6
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 6
 		b = buf[6]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 7
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 7
 		b = buf[7]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 8
 			return
 		}
-		num |= int(b&mask) << s
+		num |= int64(b&mask) << s
 		s += step
 
 		// i == 8
 		b = buf[8]
 		if b < bit {
-			num |= int(b) << s
+			num |= int64(b) << s
 			n = 9
 			return
 		}
@@ -137,7 +137,7 @@ func ProtoTag(buf []byte) (num int, typ byte, n int) {
 		return 0, 0, 0
 	}
 	if b < bit {
-		num = int(b >> typBits)
+		num = int64(b >> typBits)
 		if num == 0 {
 			return 0, 0, 0
 		}
@@ -146,97 +146,97 @@ func ProtoTag(buf []byte) (num int, typ byte, n int) {
 	} else if sz == 1 {
 		return 0, 0, 0
 	}
-	num = int((b & mask) >> typBits)
+	num = int64((b & mask) >> typBits)
 	var s uint = step - typBits
 
 	// i == 1
 	b = buf[1]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 2
 		return
 	} else if sz == 2 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 2
 	b = buf[2]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 3
 		return
 	} else if sz == 3 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 3
 	b = buf[3]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 4
 		return
 	} else if sz == 4 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 4
 	b = buf[4]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 5
 		return
 	} else if sz == 5 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 5
 	b = buf[5]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 6
 		return
 	} else if sz == 6 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 6
 	b = buf[6]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 7
 		return
 	} else if sz == 7 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 7
 	b = buf[7]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 8
 		return
 	} else if sz == 8 {
 		return 0, 0, 0
 	}
-	num |= int(b&mask) << s
+	num |= int64(b&mask) << s
 	s += step
 
 	// i == 8
 	b = buf[8]
 	if b < bit {
-		num |= int(b) << s
+		num |= int64(b) << s
 		n = 9
 		return
 	}

--- a/proto_test.go
+++ b/proto_test.go
@@ -7,32 +7,32 @@ import (
 	"testing"
 )
 
-func protoTag(buf []byte) (num int, typ byte, n int) {
+func protoTag(buf []byte) (num int64, typ byte, n int) {
 	var tag uint64
 	tag, n = Uvarint(buf)
 	if n == 0 || tag == 0 {
 		return 0, 0, 0
 	}
-	typ, num = byte(tag&0x07), int(tag>>3)
+	typ, num = byte(tag&0x07), int64(tag>>3)
 	if num <= 0 || typ > 5 {
 		return 0, 0, n
 	}
 	return
 }
 
-var casesProtoTag = []int{
-	int(MaxVal1 >> 3),
-	int(MaxVal2 >> 3),
-	int(MaxVal3 >> 3),
-	int(MaxVal4 >> 3),
-	int(MaxVal5 >> 3),
-	int(MaxVal6 >> 3),
-	int(MaxVal7 >> 3),
-	int(MaxVal8 >> 3),
-	int(MaxVal9 >> 3),
+var casesProtoTag = []int64{
+	int64(MaxVal1 >> 3),
+	int64(MaxVal2 >> 3),
+	int64(MaxVal3 >> 3),
+	int64(MaxVal4 >> 3),
+	int64(MaxVal5 >> 3),
+	int64(MaxVal6 >> 3),
+	int64(MaxVal7 >> 3),
+	int64(MaxVal8 >> 3),
+	int64(MaxVal9 >> 3),
 }
 
-func putProtoTag(b []byte, num int) int {
+func putProtoTag(b []byte, num int64) int {
 	// wire type 1, for test only
 	return binary.PutUvarint(b[:], uint64(num)<<3|1)
 }
@@ -123,7 +123,7 @@ func BenchmarkProtoTagSimple(b *testing.B) {
 
 			b.ResetTimer()
 			var (
-				num int
+				num int64
 				typ byte
 				n   int
 			)
@@ -144,7 +144,7 @@ func BenchmarkProtoTagSimple(b *testing.B) {
 
 			b.ResetTimer()
 			var (
-				num int
+				num int64
 				typ byte
 				n   int
 			)
@@ -165,7 +165,7 @@ func BenchmarkProtoTagSimple(b *testing.B) {
 
 		b.ResetTimer()
 		var (
-			num int
+			num int64
 			typ byte
 			n   int
 		)
@@ -190,7 +190,7 @@ func BenchmarkProtoTag(b *testing.B) {
 
 			b.ResetTimer()
 			var (
-				num int
+				num int64
 				typ byte
 				n   int
 			)
@@ -211,7 +211,7 @@ func BenchmarkProtoTag(b *testing.B) {
 
 			b.ResetTimer()
 			var (
-				num int
+				num int64
 				typ byte
 				n   int
 			)
@@ -232,7 +232,7 @@ func BenchmarkProtoTag(b *testing.B) {
 
 		b.ResetTimer()
 		var (
-			num int
+			num int64
 			typ byte
 			n   int
 		)


### PR DESCRIPTION
The int type size depends on the architecture, and when the type is 32-bit then 64-bit values will not fit.